### PR TITLE
fix(process-vod): roll chunks back to pending on GitHub dispatch failure

### DIFF
--- a/supabase/functions/process-vod/index.ts
+++ b/supabase/functions/process-vod/index.ts
@@ -355,7 +355,7 @@ async function processStreamOffline(event: {
     // Update chunks to 'queued' status
     const { error: updateError } = await supabase
       .from("chunks")
-      .update({ status: "queued" })
+      .update({ status: "queued", queued_at: new Date().toISOString() })
       .in("id", chunkUuids);
 
     if (updateError) {
@@ -365,14 +365,32 @@ async function processStreamOffline(event: {
       return;
     }
 
-    // Trigger GitHub workflow
-    const githubRunUrl = await triggerGithubWorkflow(
-      vodSourceId,
-      chunkUuids,
-      useOldTemplates,
-      sfdeProfileJson,
-      environment,
-    );
+    // Trigger GitHub workflow. If dispatch fails, roll chunks back to
+    // 'pending' so a future retry can pick them up — otherwise they are
+    // stranded in 'queued' forever (nothing else transitions them).
+    let githubRunUrl: string | null;
+    try {
+      githubRunUrl = await triggerGithubWorkflow(
+        vodSourceId,
+        chunkUuids,
+        useOldTemplates,
+        sfdeProfileJson,
+        environment,
+      );
+    } catch (dispatchError: any) {
+      const { error: rollbackError } = await supabase
+        .from("chunks")
+        .update({ status: "pending", queued_at: null })
+        .in("id", chunkUuids)
+        .eq("status", "queued");
+      log("error", "GitHub dispatch failed; rolled chunks back to pending", {
+        vod_source_id: vodSourceId,
+        chunks_count: chunkUuids.length,
+        dispatch_error: dispatchError.message,
+        rollback_error: rollbackError?.message,
+      });
+      throw dispatchError;
+    }
 
     recordCounter("process_vod.triggered", 1, {
       source: "eventsub",
@@ -533,7 +551,7 @@ async function handleInternalRequest(req: Request): Promise<Response> {
     console.log(`Updating ${chunks.length} chunks to 'queued' status`);
     const { error: updateError } = await supabase
       .from("chunks")
-      .update({ status: "queued" })
+      .update({ status: "queued", queued_at: new Date().toISOString() })
       .in("id", chunkUuids);
 
     if (updateError) {
@@ -543,14 +561,35 @@ async function handleInternalRequest(req: Request): Promise<Response> {
       );
     }
 
-    // Trigger GitHub workflow with all chunk UUIDs
-    const githubRunUrl = await triggerGithubWorkflow(
-      actualSourceId,
-      chunkUuids,
-      useOldTemplates,
-      sfdeProfileJson,
-      environment,
-    );
+    // Trigger GitHub workflow with all chunk UUIDs. If dispatch fails,
+    // roll chunks back to 'pending' so a future retry can pick them up —
+    // otherwise they are stranded in 'queued' forever.
+    let githubRunUrl: string | null;
+    try {
+      githubRunUrl = await triggerGithubWorkflow(
+        actualSourceId,
+        chunkUuids,
+        useOldTemplates,
+        sfdeProfileJson,
+        environment,
+      );
+    } catch (dispatchError: any) {
+      const { error: rollbackError } = await supabase
+        .from("chunks")
+        .update({ status: "pending", queued_at: null })
+        .in("id", chunkUuids)
+        .eq("status", "queued");
+      console.error(
+        "GitHub dispatch failed; rolled chunks back to pending",
+        {
+          vod_id: actualVodId,
+          chunks_count: chunkUuids.length,
+          dispatch_error: dispatchError.message,
+          rollback_error: rollbackError?.message,
+        },
+      );
+      throw dispatchError;
+    }
 
     recordCounter("process_vod.triggered", 1, { source: "internal" });
 


### PR DESCRIPTION
# Stop leaving chunks stranded in `queued` when GitHub dispatch fails

## Problem

When `process-vod` flips chunks to `status='queued'` and then the subsequent `POST /actions/workflows/process-vod.yml/dispatches` call fails — rate limit, bad token, network error, invalid payload — the chunks are left in `queued` **forever**. Nothing else transitions them: SFDE is what moves a chunk from `queued → processing` (by writing `started_at`), and if the workflow never launches, no SFDE container ever runs.

The outer `catch` just logs. There's no rollback.

## Evidence

**29 chunks across 12 VODs currently stuck** in `queued`, with `queued_at=null`, `started_at=null`, `attempt_count=0`, `last_error=null`:

| Cluster | Chunks | VODs | Streamers |
|---|---|---|---|
| 2026-03-05 | 22 | 8 | theprojectlazarus, marvelchuftw, sharodiza_lk, mr_z1o, lethalfrag, sn1ceer, afkwoot, qiraj |
| 2026-03-12 | 2 | 2 | veetoqc, coughins |
| 2026-04-06/07 | 5 | 2 | anasthasiusfocht, merimides |

All 12 parent VODs are `status='processing'`. Three tight time clusters suggest three GitHub incidents / deploys. The `queued_at=null` is diagnostic: the code that wrote `status='queued'` never set a timestamp, so even a watchdog couldn't distinguish legitimate queued chunks from stranded ones.

This is what blocked ragnarregis's force-reprocessed VODs from moving — `force_process_vod` flipped them to `queued`, and they got stuck behind the existing clog.

## Fix

Two call sites in `supabase/functions/process-vod/index.ts` (EventSub handler + internal API handler) had the same shape:

```ts
await supabase.from("chunks").update({ status: "queued" }).in("id", chunkUuids);
const githubRunUrl = await triggerGithubWorkflow(...);  // can throw
```

Replaced with:

1. Also set `queued_at = now()` on the flip (the column was in the schema but unused)
2. Wrap dispatch in `try/catch`; on failure, update `WHERE status='queued'` back to `pending` with `queued_at=null`, then rethrow
3. The `eq('status','queued')` guard ensures we don't clobber chunks SFDE might have already raced ahead to pick up

